### PR TITLE
remove the '--email' parameter from docker login

### DIFF
--- a/buildimg.sh
+++ b/buildimg.sh
@@ -28,6 +28,6 @@ if [ "${TRAVIS_BRANCH}" == "master" ]; then
 elif [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
   echo -e "\n\nWe're not uploading images from pull requests."
 else
-  docker login -e 'none' -u "$QUAY_USER" -p "$QUAY_PASS" quay.io
+  docker -u "$QUAY_USER" -p "$QUAY_PASS" quay.io
   docker push "$TAGNAME"
 fi


### PR DESCRIPTION
Like Travis' docker says:
`Flag --email has been deprecated, will be removed in 1.13.`
